### PR TITLE
refactors codebase to utilise api-key db

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,5 +1,9 @@
 const { riskManageVolume } = require("../utils/riskManagement");
 const { retrieveBalance } = require("../models/data.model");
+const { getAllApiKeys } = require("../models/apiKeys.model");
+const { seed } = require("../db/seeds/seed");
+const testData = require("../db/test-data/apiKeys");
+const db = require("../db/connection");
 
 jest.mock("../models/data.model");
 
@@ -83,5 +87,74 @@ describe("riskManageVolume", () => {
     });
     const actual = await riskManageVolume(...input);
     expect(actual).toBe(0.007137931034482759);
+  });
+});
+
+beforeEach(async () => {
+  await seed(testData);
+});
+
+afterAll(async () => {
+  await db.end();
+});
+
+describe.only("getAllApiKeys", () => {
+  it("should when successful return an array of objects containing user api keys", async () => {
+    const expected = [
+      {
+        username: "john_doe",
+        api_key: "123abc456def",
+        private_key: "private_key_john_doe",
+      },
+      {
+        username: "jane_smith",
+        api_key: "789ghi012jkl",
+        private_key: "private_key_jane_smith",
+      },
+      {
+        username: "michael_brown",
+        api_key: "345mno678pqr",
+        private_key: "private_key_michael_brown",
+      },
+      {
+        username: "lisa_jones",
+        api_key: "901stu234vwx",
+        private_key: "private_key_lisa_jones",
+      },
+      {
+        username: "emma_davis",
+        api_key: "567yzx890abc",
+        private_key: "private_key_emma_davis",
+      },
+      {
+        username: "william_miller",
+        api_key: "123cde456fgh",
+        private_key: "private_key_william_miller",
+      },
+      {
+        username: "sophia_wilson",
+        api_key: "789ijk012lmn",
+        private_key: "private_key_sophia_wilson",
+      },
+      {
+        username: "liam_moore",
+        api_key: "345opq678rst",
+        private_key: "private_key_liam_moore",
+      },
+      {
+        username: "olivia_taylor",
+        api_key: "901uvw234xyz",
+        private_key: "private_key_olivia_taylor",
+      },
+      {
+        username: "noah_anderson",
+        api_key: "567bcd890efg",
+        private_key: "private_key_noah_anderson",
+      },
+    ];
+
+    const actual = await getAllApiKeys();
+
+    expect(actual).toEqual(expected);
   });
 });

--- a/app.js
+++ b/app.js
@@ -29,10 +29,13 @@ const {
   deleteUserApiKeys,
 } = require("./controllers/apiKeys.controller");
 const { handlePsqlErrors } = require("./errors/errorHandlers");
+const { testRoute } = require("./utils/verification");
+require("dotenv").config();
 
 const app = express();
 
 app.use(express.json());
+app.use(testRoute);
 
 // Kraken
 app.get("/get-balance", verifyAccessToken, getBalance);

--- a/controllers/data.controller.js
+++ b/controllers/data.controller.js
@@ -1,3 +1,4 @@
+const { selectUserApiKeys } = require("../models/apiKeys.model");
 const {
   retrieveBalance,
   retrieveOpenOrders,
@@ -5,8 +6,11 @@ const {
 } = require("../models/data.model");
 
 exports.getBalance = async (req, res) => {
+  const username = req.user.username;
+  const token = req.headers.authorization?.split(" ")[1];
   try {
-    const balanceData = await retrieveBalance();
+    const user = await selectUserApiKeys(username, token);
+    const balanceData = await retrieveBalance(user.apiKey, user.privateKey);
 
     res.status(200).send({ balanceData });
   } catch (error) {
@@ -18,8 +22,14 @@ exports.getBalance = async (req, res) => {
 };
 
 exports.getOpenOrders = async (req, res) => {
+  const username = req.user.username;
+  const token = req.headers.authorization?.split(" ")[1];
   try {
-    const openOrdersData = await retrieveOpenOrders();
+    const user = await selectUserApiKeys(username, token);
+    const openOrdersData = await retrieveOpenOrders(
+      user.apiKey,
+      user.privateKey
+    );
 
     res.status(200).send({ openOrdersData });
   } catch (error) {
@@ -31,8 +41,12 @@ exports.getOpenOrders = async (req, res) => {
 };
 
 exports.getPnl = async (req, res) => {
+  const username = req.user.username;
+  const token = req.headers.authorization?.split(" ")[1];
   try {
-    const unrealisedPnl = await retrievePnl();
+    const user = await selectUserApiKeys(username, token);
+    const unrealisedPnl = await retrievePnl(user.apiKey,
+      user.privateKey);
 
     res.status(200).send({ unrealisedPnl });
   } catch (error) {

--- a/controllers/order.controller.js
+++ b/controllers/order.controller.js
@@ -1,3 +1,4 @@
+const { getAllApiKeys, selectUserApiKeys } = require("../models/apiKeys.model");
 const {
   createOrder,
   createTakeProfitOrder,
@@ -7,36 +8,29 @@ const {
   updateOrderById,
 } = require("../models/order.model");
 const { riskManageVolume } = require("../utils/riskManagement");
+const { placeOrderForUser } = require("../utils/orderUtils");
 
 exports.placeOrder = async (req, res) => {
   try {
-    const { action, quantity, ticker, price, stopLoss, takeProfit, validate } =
-      req.body;
+    const { action, ticker, price, stopLoss, takeProfit, validate } = req.body;
 
-    const orderVolume = await riskManageVolume(price, stopLoss, 0.01, "USDT");
+    const apiKeys = await getAllApiKeys();
 
-    const orderData = await createOrder(
-      action,
-      orderVolume,
-      ticker,
-      price,
-      stopLoss,
-      validate
+    const results = await Promise.all(
+      apiKeys.map(async (user) => {
+        return placeOrderForUser(
+          user,
+          action,
+          ticker,
+          price,
+          stopLoss,
+          takeProfit,
+          validate
+        );
+      })
     );
 
-    const takeProfitOrderData = await createTakeProfitOrder(
-      action,
-      orderVolume,
-      takeProfit,
-      validate
-    );
-
-    if (!validate) {
-      const orderId = orderData.txid[0];
-      trackPositionStatus(orderId);
-    }
-
-    res.status(201).send({ orderData, takeProfitOrderData });
+    res.status(201).send({ results });
   } catch (error) {
     console.error("Error placing order:", error);
     res
@@ -46,9 +40,17 @@ exports.placeOrder = async (req, res) => {
 };
 
 exports.cancelOrderById = async (req, res) => {
+  const username = req.user.username;
+  const token = req.headers.authorization?.split(" ")[1];
+  const { txid } = req.body;
   try {
-    const { txid } = req.body;
-    const removalData = await removeOrderById(txid);
+    const user = await selectUserApiKeys(username, token);
+
+    const removalData = await removeOrderById(
+      txid,
+      user.apiKey,
+      user.privateKey
+    );
 
     res.status(200).send({ removalData });
   } catch (error) {
@@ -60,8 +62,13 @@ exports.cancelOrderById = async (req, res) => {
 };
 
 exports.cancelAllOrders = async (req, res) => {
+  const username = req.user.username;
+  const token = req.headers.authorization?.split(" ")[1];
   try {
-    const removalData = await removeAllOrders();
+    const user = await selectUserApiKeys(username, token);
+
+    const removalData = await removeAllOrders(user.apiKey,
+      user.privateKey);
 
     res.status(200).send({ removalData });
   } catch (error) {
@@ -73,10 +80,13 @@ exports.cancelAllOrders = async (req, res) => {
 };
 
 exports.editOrder = async (req, res) => {
+  const username = req.user.username;
+  const token = req.headers.authorization?.split(" ")[1];
+  const { txid, price } = req.body;
   try {
-    const { txid, price } = req.body;
+    const user = await selectUserApiKeys(username, token);
 
-    const updatedOrderData = await updateOrderById(txid, price);
+    const updatedOrderData = await updateOrderById(txid, price, user.apiKey, user.privateKey);
 
     res.status(200).send({ updatedOrderData });
   } catch (error) {

--- a/models/apiKeys.model.js
+++ b/models/apiKeys.model.js
@@ -51,7 +51,7 @@ exports.addUserApiKeys = async (username, email, apiKey, privateKey, token) => {
 exports.updateApiKeysByUser = async (username, apiKey, privateKey, token) => {
   try {
     verifyUsernameByToken(username, token);
-    await checkUserExists(username)
+    await checkUserExists(username);
 
     if (!apiKey || !privateKey) {
       throw { status: 400, message: "Missing required field." };
@@ -89,5 +89,18 @@ exports.removeUserApiKeys = async (username, token) => {
     );
   } catch (error) {
     throw error;
+  }
+};
+
+exports.getAllApiKeys = async () => {
+  try {
+    const response = await db.query(
+      `
+      SELECT username, api_key, private_key FROM api_keys
+      `
+    );
+    return response.rows
+  } catch (error) {
+    throw error
   }
 };

--- a/models/data.model.js
+++ b/models/data.model.js
@@ -1,22 +1,27 @@
 const { krakenRequest } = require("../utils/helperFunctions");
 
-exports.retrieveBalance = () => {
+exports.retrieveBalance = (apiKey, apiSecret) => {
   const path = "/0/private/Balance";
-  return krakenRequest(path);
+  return krakenRequest(path, undefined, apiKey, apiSecret);
 };
 
-exports.retrieveOpenOrders = () => {
+exports.retrieveOpenOrders = (apiKey, apiSecret) => {
   const path = "/0/private/OpenOrders";
-  return krakenRequest(path);
+  return krakenRequest(path, undefined, apiKey, apiSecret);
 };
 
-exports.retrievePnl = async () => {
+exports.retrievePnl = async (apiKey, apiSecret) => {
   try {
     const path = "/0/private/TradeBalance";
 
-    const tradeBalance = await krakenRequest(path);
+    const tradeBalance = await krakenRequest(
+      path,
+      undefined,
+      apiKey,
+      apiSecret
+    );
 
-    return tradeBalance.v
+    return tradeBalance.v;
   } catch (error) {
     throw error;
   }

--- a/models/order.model.js
+++ b/models/order.model.js
@@ -9,7 +9,9 @@ exports.createOrder = async (
   pair,
   price,
   stopLoss,
-  validate = false
+  validate = false,
+  apiKey,
+  apiSecret
 ) => {
   try {
     validateOrderInputs(type, volume, price, stopLoss);
@@ -27,7 +29,7 @@ exports.createOrder = async (
       validate,
     };
 
-    return krakenRequest(path, request);
+    return krakenRequest(path, request, apiKey, apiSecret);
   } catch (error) {
     throw error;
   }
@@ -37,7 +39,9 @@ exports.createTakeProfitOrder = async (
   type,
   volume,
   price,
-  validate = false
+  validate = false,
+  apiKey,
+  apiSecret
 ) => {
   try {
     validateOrderInputs(type, volume, price);
@@ -56,7 +60,7 @@ exports.createTakeProfitOrder = async (
       validate,
     };
 
-    return krakenRequest(path, request);
+    return krakenRequest(path, request, apiKey, apiSecret);
   } catch (error) {
     throw error;
   }
@@ -94,22 +98,25 @@ exports.trackPositionStatus = async (initialOrderId) => {
   }, 60000); // Check every minute
 };
 
-exports.removeOrderById = async (orderId) => {
+exports.removeOrderById = async (orderId, apiKey, privateKey) => {
   const path = "/0/private/CancelOrder";
+  try {
+    const request = {
+      txid: orderId,
+    };
 
-  const request = {
-    txid: orderId,
-  };
-
-  return krakenRequest(path, request);
+    return krakenRequest(path, request, apiKey, privateKey);
+  } catch (error) {
+    throw error;
+  }
 };
 
-exports.removeAllOrders = async () => {
+exports.removeAllOrders = async (apiKey, privateKey) => {
   const path = "/0/private/CancelAll";
-  return krakenRequest(path);
+  return krakenRequest(path, undefined, apiKey, privateKey);
 };
 
-exports.updateOrderById = async (orderId, price) => {
+exports.updateOrderById = async (orderId, price, apiKey, privateKey) => {
   try {
     validateOrderInputs(undefined, undefined, price);
 
@@ -121,7 +128,7 @@ exports.updateOrderById = async (orderId, price) => {
       price,
     };
 
-    return krakenRequest(path, request);
+    return krakenRequest(path, request, apiKey, privateKey);
   } catch (error) {
     throw error;
   }

--- a/utils/helperFunctions.js
+++ b/utils/helperFunctions.js
@@ -2,15 +2,26 @@ const crypto = require("crypto");
 const axios = require("axios");
 const { URLSearchParams } = require("url");
 const { apiKey, apiSecret } = require("./keys");
+const { getAllApiKeys } = require("../models/apiKeys.model");
 
+// const kraken = axios.create({
+//   baseURL: "https://api.kraken.com",
+//   headers: {
+//     "API-Key": apiKey,
+//     "Content-Type": "application/x-www-form-urlencoded",
+//   },
+// });
 
-const kraken = axios.create({
-  baseURL: "https://api.kraken.com",
-  headers: {
-    "API-Key": apiKey,
-    "Content-Type": "application/x-www-form-urlencoded",
-  },
-});
+const createAxiosConnection = (apiKey) => {
+  const kraken = axios.create({
+    baseURL: "https://api.kraken.com",
+    headers: {
+      "API-Key": apiKey,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+  });
+  return kraken;
+};
 
 const getKrakenSignature = (path, request, secret, nonce) => {
   const message = new URLSearchParams(request).toString();
@@ -28,7 +39,7 @@ const createNonce = () => {
   return Date.now() * 1000;
 };
 
-exports.krakenRequest = async (path, request) => {
+exports.krakenRequest = async (path, request, apiKey, apiSecret) => {
   const nonce = createNonce();
   const signature = getKrakenSignature(
     path,
@@ -36,6 +47,8 @@ exports.krakenRequest = async (path, request) => {
     apiSecret,
     nonce
   );
+
+  const kraken = createAxiosConnection(apiKey);
 
   try {
     const response = await kraken.post(
@@ -75,4 +88,3 @@ exports.validateOrderInputs = (type, volume, price, stopLoss) => {
 exports.roundToTwoDecimals = (num) => {
   return Math.round(num * 100) / 100;
 };
-

--- a/utils/orderUtils.js
+++ b/utils/orderUtils.js
@@ -1,0 +1,59 @@
+const { riskManageVolume } = require("./riskManagement");
+const {
+  createOrder,
+  createTakeProfitOrder,
+  trackPositionStatus,
+  removeAllOrders,
+  removeOrderById,
+  updateOrderById,
+} = require("../models/order.model");
+
+exports.placeOrderForUser = async (
+  user,
+  action,
+  ticker,
+  price,
+  stopLoss,
+  takeProfit,
+  validate
+) => {
+  try {
+    const orderVolume = await riskManageVolume(
+      price,
+      stopLoss,
+      0.01,
+      "USDT",
+      user.api_key,
+      user.private_key
+    );
+
+    const orderData = await createOrder(
+      action,
+      orderVolume,
+      ticker,
+      price,
+      stopLoss,
+      validate,
+      user.api_key,
+      user.private_key
+    );
+
+    const takeProfitOrderData = await createTakeProfitOrder(
+      action,
+      orderVolume,
+      takeProfit,
+      validate,
+      user.api_key,
+      user.private_key
+    );
+
+    if (!validate) {
+      const orderId = orderData.txid[0];
+      trackPositionStatus(orderId);
+    }
+
+    return { user: user.username, orderData, takeProfitOrderData };
+  } catch (error) {
+    return { user: user.username, error: error.message };
+  }
+};

--- a/utils/riskManagement.js
+++ b/utils/riskManagement.js
@@ -1,8 +1,15 @@
 const { retrieveBalance } = require("../models/data.model");
 const { roundToTwoDecimals } = require("../utils/helperFunctions");
 
-exports.riskManageVolume = async (entry, stopLoss, riskPerc, baseCurrency) => {
-  const accountBalance = await retrieveBalance();
+exports.riskManageVolume = async (
+  entry,
+  stopLoss,
+  riskPerc,
+  baseCurrency,
+  apiKey,
+  apiSecret
+) => {
+  const accountBalance = await retrieveBalance(apiKey, apiSecret);
 
   const roundedAccountBalance = roundToTwoDecimals(
     accountBalance[baseCurrency]

--- a/utils/verification.js
+++ b/utils/verification.js
@@ -6,3 +6,10 @@ exports.verifyUsernameByToken = (username, token) => {
     throw { status: 401, message: "Unauthorized access." };
   }
 };
+
+exports.testRoute = (req, res, next) => {
+  if (process.env.NODE_ENV === "test") {
+    req.user = { username: "john_doe" };
+  }
+  next();
+};


### PR DESCRIPTION
This Branch:
- refactors many of the endpoints to utilise the api key db
- ensuring users can make requests to access their own data and trades, rather than the code base getting api keys from environment variables 

Notes:
- The verifyUsernameByToken functions is redundant now. Although still used, refactoring to eliminate its use could be wise.
- The logic for cancelling left open trades needs rethinking. Definitley a better way to do it than current model. Havent yet refactored current model to use the database either.